### PR TITLE
Added undefined check when accessing style.paddingLeft in dynamic-column-width implementation

### DIFF
--- a/libs/ngrid/src/lib/table/col-width-logic/dynamic-column-width.ts
+++ b/libs/ngrid/src/lib/table/col-width-logic/dynamic-column-width.ts
@@ -104,13 +104,13 @@ export class DynamicColumnWidthLogic {
 export const DYNAMIC_PADDING_BOX_MODEL_SPACE_STRATEGY: BoxModelSpaceStrategy = {
   cell(col: PblColumnSizeInfo): number {
     const style = col.style;
-    return parseInt(style.paddingLeft) + parseInt(style.paddingRight)
+    return style ? parseInt(style.paddingLeft) + parseInt(style.paddingRight) : 0
   },
   groupCell(col: PblColumnSizeInfo): number {
     return 0;
   },
   group(cols: PblColumnSizeInfo[]): number {
     const len = cols.length;
-    return len > 0 ? parseInt(cols[0].style.paddingLeft) + parseInt(cols[len - 1].style.paddingRight) : 0;
+    return len > 0 && cols[0].style && cols[len - 1].style ? parseInt(cols[0].style.paddingLeft) + parseInt(cols[len - 1].style.paddingRight) : 0;
   }
 };


### PR DESCRIPTION
Ngrid is crashing in the dynamic-column-width implementation when column width is not configured. Presumably style is not created and the logic expects a column with defined style.
The code is pretty complex and potentially it should not happen - maybe style not being set is an unexpected situation and setting the style should be fixed, yet surely crashing was not intended so I added checks for column style.

Potentially this is related to another issue - when column widths are defined in a way that one column has no width defined, and only minWidth set, when scrolling a longer lists columns get shifted.

Is it mandatory for all columns to have width set to percentage if any of the columns have percentage set? Image attached to show a problem.
![image](https://user-images.githubusercontent.com/1933165/68948185-38182880-07af-11ea-9842-51c3847445b3.png)
![image](https://user-images.githubusercontent.com/1933165/68948203-42d2bd80-07af-11ea-8a3d-ef3b6bd25b84.png)
