### PR TITLE
Fixed Uncaught Error: ViewDestroyedError: Attempt to use a destroyed view: detectChanges when window is resized during switching dataSource items and selection

### DIFF
--- a/libs/ngrid/src/lib/table/features/virtual-scroll/virtual-scroll-viewport.component.ts
+++ b/libs/ngrid/src/lib/table/features/virtual-scroll/virtual-scroll-viewport.component.ts
@@ -254,7 +254,7 @@ export class PblCdkVirtualScrollViewportComponent extends CdkVirtualScrollViewpo
       this.scrollHeight = this.elementRef.nativeElement.scrollHeight; //size;
       this.updateFiller();
       // We must trigger a change detection cycle because the filler div element is updated through bindings
-      this.cdr.detectChanges();
+      this.cdr.markForCheck();
     })
   }
 


### PR DESCRIPTION
When ngrid component is dynamically shown/hidden, change detection is triggered for a view which is being destroyed and at the same time parent component resized to collapse a placeholder for the grid. ChangeDetectorRef.detectChanges will throw an error if view is destroyed and calling markForCheck instead will prevent this.

Obviously markForCheck will wait for next cycle but I could not spot any adverse effects of this change - filler is resized accordingly and height is updated correctly.

Again, code is pretty complex and potentially setTotalContentSize should never be called when destroying and resizing takes place.