### PR TITLE
refactor(core): refactor width change detection

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,46 +2,36 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "type": "node",
+      "name": "browser: ng serve (launch: CLI)",
+      "type": "chrome",
       "request": "launch",
-      "name": "NG SERVE - DEBUG",
-      "program": "${workspaceFolder}/node_modules/.bin/ng",
-      "args": [
-        "serve"
-      ]
+      "preLaunchTask": "npm: start",
+      "url": "http://localhost:4201/#",
+      "webRoot": "${workspaceFolder}",
+      "sourceMapPathOverrides": {
+        "webpack:////*": "/*",
+        "webpack:/*": "${webRoot}/*"
+      }
     },
     {
-      "type": "node",
+      "name": "browser: ng serve",
+      "type": "chrome",
       "request": "launch",
-      "name": "NG BUILD - DEBUG",
-      "program": "${workspaceFolder}/node_modules/.bin/ng",
-      "args": [
-        "build",
-        "ngrid",
-        "--prod"
-      ]
+      "url": "http://localhost:4201/#",
+      "webRoot": "${workspaceFolder}/apps/ngrid-demo-app",
+      "sourceMapPathOverrides": {
+        "webpack:////*": "/*",
+        "webpack:/*": "${webRoot}/*"
+      },
     },
     {
-      "type": "node",
-      "request": "launch",
-      "name": "NX SCHEMATIC - DEBUG",
-      "program": "${workspaceFolder}/node_modules/.bin/nx",
-      "cwd": "${workspaceFolder}",
-      "args": [
-        "workspace-schematic",
-        "example-module",
-        "features/column/CellEdit",
-        "--add",
-        "MyTestRun"
-      ]
-    },
-    {
-      "name": "ng serve - attach",
+      "name": "browser: ng serve (attach only)",
       "type": "chrome",
       "request": "attach",
       "urlFilter": "http://localhost:4201*",
       "webRoot": "${workspaceFolder}",
       "sourceMapPathOverrides": {
+        "webpack:////*": "/*",
         "webpack:/*": "${webRoot}/*"
       },
       "port": 9222
@@ -60,6 +50,40 @@
       "program": "${workspaceFolder}/node_modules/protractor/bin/protractor",
       "protocol": "inspector",
       "args": ["${workspaceFolder}/protractor.conf.js"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "node: ng serve",
+      "program": "${workspaceFolder}/node_modules/.bin/ng",
+      "args": [
+        "serve"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "node: ng build",
+      "program": "${workspaceFolder}/node_modules/.bin/ng",
+      "args": [
+        "build",
+        "ngrid",
+        "--prod"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "node: nx schematics",
+      "program": "${workspaceFolder}/node_modules/.bin/nx",
+      "cwd": "${workspaceFolder}",
+      "args": [
+        "workspace-schematic",
+        "example-module",
+        "features/column/CellEdit",
+        "--add",
+        "MyTestRun"
+      ]
     },
     {
       "name": "[Node] Current TS File",

--- a/apps/libs/ngrid-examples/features/column/column-resize/resizing-with-the-api.component.html
+++ b/apps/libs/ngrid-examples/features/column/column-resize/resizing-with-the-api.component.html
@@ -1,3 +1,3 @@
-<button (click)="resize(pblTable1)">Resize id to 200px</button>
+<button (click)="resize()">Resize id to 200px</button>
 <button (click)="pblTable1.autoSizeColumnToFit()">Fit Content</button>
 <pbl-ngrid #pblTable1 [dataSource]="ds" [columns]="columns" class="pbl-ngrid-cell-ellipsis pbl-ngrid-header-cell-ellipsis"></pbl-ngrid>

--- a/apps/libs/ngrid-examples/features/column/column-resize/resizing-with-the-api.component.ts
+++ b/apps/libs/ngrid-examples/features/column/column-resize/resizing-with-the-api.component.ts
@@ -17,9 +17,9 @@ export class ResizingWithTheApiExample {
   columns = columnFactory()
     .table(
       { prop: 'id', width: '40px' },
-      { prop: 'name' },
+      { prop: 'name', width: '15%' },
       { prop: 'gender', width: '50px' },
-      { prop: 'birthdate', type: 'date' }
+      { prop: 'birthdate', type: 'date', maxWidth: 120 }
     )
     .build();
 
@@ -27,8 +27,8 @@ export class ResizingWithTheApiExample {
 
   constructor(private datasource: DemoDataSource) { }
 
-  resize(table: PblNgridComponent<Person>): void {
-    const id = table.columnApi.findColumn('id');
-    table.columnApi.resizeColumn(id, '200px');
+  resize(): void {
+    const id = this.ds.hostGrid.columnApi.findColumn('id');
+    this.ds.hostGrid.columnApi.resizeColumn(id, '200px');
   }
 }

--- a/apps/libs/ngrid-examples/features/column/width/min-column-width.component.ts
+++ b/apps/libs/ngrid-examples/features/column/width/min-column-width.component.ts
@@ -18,12 +18,16 @@ export class MinColumnWidthFeatureExample {
     .table(
       { prop: 'id', width: '50px', pIndex: true },
       { prop: 'name', width: '25%' },
-      { prop: 'email', minWidth: 250 },
+      { prop: 'email', minWidth: 450},
       { prop: 'country', width: '35%' },
       { prop: 'language', maxWidth: 50 },
       { prop: 'settings.timezone', label: 'TZ', width: '30px' },
       { prop: 'balance' },
       { prop: 'gender' },
+    )
+    .headerGroup(
+      { prop: 'name', span: 1, label: 'Name & Email' },
+      { prop: 'country', span: 1, label: 'Country & Language' },
     )
     .build();
   ds = createDS<Person>().onTrigger( () => this.datasource.getPeople(0, 5) ).create();

--- a/libs/ngrid/drag/src/lib/column-resize/column-resize.component.ts
+++ b/libs/ngrid/drag/src/lib/column-resize/column-resize.component.ts
@@ -1,14 +1,25 @@
 import { animationFrameScheduler, Subscription } from 'rxjs';
 import { auditTime, take } from 'rxjs/operators';
-
-import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, HostListener, Inject, Input, Optional, OnDestroy, NgZone, ViewEncapsulation } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  HostListener,
+  Inject,
+  Input,
+  Optional,
+  OnDestroy,
+  NgZone,
+  ViewEncapsulation
+} from '@angular/core';
 
 import { Directionality } from '@angular/cdk/bidi';
 import { ViewportRuler } from '@angular/cdk/scrolling';
 import { normalizePassiveListenerOptions } from '@angular/cdk/platform';
 import { CdkDragConfig, DragDropRegistry, CDK_DRAG_CONFIG } from '@angular/cdk/drag-drop';
 
-import { PblNgridComponent, PblColumn, PblNgridMetaCellContext, TablePlugin } from '@pebula/ngrid';
+import { PblNgridComponent, PblColumn, PblNgridMetaCellContext, TablePlugin, isPblColumn } from '@pebula/ngrid';
 import { toggleNativeDragInteractions } from './cdk-encapsulated-code';
 import { extendGrid } from './extend-grid';
 
@@ -44,7 +55,7 @@ export class PblNgridDragResizeComponent implements AfterViewInit, OnDestroy {
   @Input() set context(value: PblNgridMetaCellContext<any>) {
     if (value) {
       const { col, table } = value;
-      if (col && col instanceof PblColumn) {
+      if (isPblColumn(col)) {
         this.column = col;
         this.table = table;
         return;

--- a/libs/ngrid/src/index.ts
+++ b/libs/ngrid/src/index.ts
@@ -25,6 +25,7 @@ export {
   PEB_NGRID_CONFIG, PblNgridConfig, PblNgridConfigService,
 
   PblColumn, PblMetaColumn, PblColumnGroup, PblColumnFactory, COLUMN, columnFactory,
+  isPblMetaColumn, isPblColumnGroup, isPblColumn,
 
   PBL_NGRID_ROW_TEMPLATE, PblNgridRowComponent,
 

--- a/libs/ngrid/src/lib/table/col-width-logic/dynamic-column-width.ts
+++ b/libs/ngrid/src/lib/table/col-width-logic/dynamic-column-width.ts
@@ -36,17 +36,13 @@ export class DynamicColumnWidthLogic {
   private readonly cols = new Map<PblColumnSizeInfo, number>();
   private _minimumRowWidth = 0;
 
-  constructor(private strategy: BoxModelSpaceStrategy) { }
+  constructor(public readonly strategy: BoxModelSpaceStrategy) { }
 
   /**
    * Returns a breakout of the width of the column, breaking it into the width of the content and the rest of the width
    */
   widthBreakout(columnInfo: PblColumnSizeInfo): { content: number, nonContent: number } {
-    const nonContent = this.strategy.cell(columnInfo);
-    return {
-      content: columnInfo.width - nonContent,
-      nonContent,
-    };
+    return widthBreakout(this.strategy, columnInfo);
   }
 
   /**
@@ -99,6 +95,17 @@ export class DynamicColumnWidthLogic {
    return sum;
   }
 
+}
+
+/**
+* Returns a breakout of the width of the column, breaking it into the width of the content and the rest of the width
+*/
+export function widthBreakout(strategy: BoxModelSpaceStrategy, columnInfo: PblColumnSizeInfo): { content: number, nonContent: number } {
+ const nonContent = strategy.cell(columnInfo);
+ return {
+   content: columnInfo.width - nonContent,
+   nonContent,
+ };
 }
 
 export const DYNAMIC_PADDING_BOX_MODEL_SPACE_STRATEGY: BoxModelSpaceStrategy = {

--- a/libs/ngrid/src/lib/table/column-api.ts
+++ b/libs/ngrid/src/lib/table/column-api.ts
@@ -1,6 +1,6 @@
 import { PblNgridExtensionApi } from '../ext/table-ext-api';
 import { PblNgridComponent } from './table.component';
-import { PblColumn } from './columns/column';
+import { PblColumn, isPblColumn } from './columns/column';
 import { PblColumnStore } from './columns/column-store';
 
 export interface AutoSizeToFitOptions {
@@ -109,9 +109,9 @@ export class ColumnApi<T> {
    * Resizing the column will trigger a table width resizing event, updating column group if necessary.
    */
   resizeColumn(column: PblColumn, width: string): void {
-    column.updateWidth(true, width)
-    this.table.resetColumnsWidth();
-    this.table.resizeColumns();
+    column.updateWidth(width);
+    // this.table.resetColumnsWidth();
+    // this.table.resizeColumns();
   }
 
   /**
@@ -144,10 +144,10 @@ export class ColumnApi<T> {
     const cols = columns.length > 0 ? columns : this.visibleColumns;
     for (const column of cols) {
       const size = this.findColumnAutoSize(column);
-      column.updateWidth(true, `${size}px`)
+      column.updateWidth(`${size}px`);
     }
-    this.table.resetColumnsWidth();
-    this.table.resizeColumns();
+    // this.table.resetColumnsWidth();
+    // this.table.resizeColumns();
   }
 
   /**
@@ -198,7 +198,7 @@ export class ColumnApi<T> {
       }
       if (!instructions.keepMaxWidth || !column.maxWidth) {
         column.maxWidth = undefined;
-         column.checkMaxWidthLock(column.sizeInfo.width); // if its locked, we need to release...
+        column.checkMaxWidthLock(column.sizeInfo.width); // if its locked, we need to release...
       }
 
       // There are 3 scenarios when updating the column
@@ -214,14 +214,13 @@ export class ColumnApi<T> {
       } // else (3) -> the update is skipped and it will run through resetColumnsWidth
 
       if (width) {
-        // We're not updating the width width markForCheck set to true because it will be done right after in `this.table.resetColumnsWidth()`
-        column.updateWidth(false, width);
+        column.updateWidth(width);
       }
 
     }
     // we now reset the column widths, this will calculate a new `defaultWidth` and set it in all columns but the relevant ones are column from (3)
-    // It will also mark all columnDef's for check
-    this.table.resetColumnsWidth({ tableMarkForCheck: true });
+    // It will also mark all columnDefs for check
+    this.table.resetColumnsWidth();
     this.table.resizeColumns();
   }
 
@@ -237,7 +236,7 @@ export class ColumnApi<T> {
    */
   moveColumn(column: PblColumn, renderColumnIndex: number, skipRedraw?: boolean): boolean; // tslint:disable-line:unified-signatures
   moveColumn(column: PblColumn, anchor: PblColumn | number, skipRedraw?: boolean): boolean {
-    if (anchor instanceof PblColumn) {
+    if (isPblColumn(anchor)) {
       const result = column === anchor ? false : this.store.moveColumn(column, anchor);
       if (result && skipRedraw !== true) {
         this.afterColumnPositionChange();

--- a/libs/ngrid/src/lib/table/columns/column.ts
+++ b/libs/ngrid/src/lib/table/columns/column.ts
@@ -13,7 +13,7 @@ const PBL_NGRID_COLUMN_MARK = Symbol('PblColumn');
 const CLONE_PROPERTIES: Array<keyof PblColumn> = ['pIndex', 'transform', 'filter', 'sort', 'alias', 'headerType', 'footerType', 'pin'];
 
 export function isPblColumn(def: any): def is PblColumn {
-  return def instanceof PblColumn || def[PBL_NGRID_COLUMN_MARK] === true;
+  return def instanceof PblColumn || (def && def[PBL_NGRID_COLUMN_MARK] === true);
 }
 
 export class PblColumn implements PblColumnDefinition {
@@ -264,7 +264,7 @@ export class PblColumn implements PblColumnDefinition {
     this.detach();
     this._columnDef = columnDef;
     if (this.defaultWidth) {
-      this.columnDef.updateWidth(this.width || this.defaultWidth);
+      this.columnDef.updateWidth(this.width || this.defaultWidth, 'attach');
     }
   }
 
@@ -276,16 +276,13 @@ export class PblColumn implements PblColumnDefinition {
     this.defaultWidth = defaultWidth;
   }
 
-  updateWidth(markForCheck: boolean, width?: string): void {
+  updateWidth(width?: string): void {
     if (width) {
       this.width = width;
     }
     const { columnDef } = this;
     if (columnDef) {
-      columnDef.updateWidth(this.width || this.defaultWidth || '');
-      if (markForCheck) {
-        columnDef.markForCheck();
-      }
+      columnDef.updateWidth(this.width || this.defaultWidth || '', 'update');
     }
   }
 

--- a/libs/ngrid/src/lib/table/columns/group-column.ts
+++ b/libs/ngrid/src/lib/table/columns/group-column.ts
@@ -1,13 +1,13 @@
 import { PblNgridColumnDef } from '../directives';
-import { PblBaseColumnDefinition, PblColumnGroupDefinition } from './types';
+import { PblColumnGroupDefinition } from './types';
 import { PblMetaColumn } from './meta-column';
 import { PblColumn } from './column';
 
 const PBL_NGRID_COLUMN_GROUP_MARK = Symbol('PblColumnGroup');
 const CLONE_PROPERTIES: Array<keyof PblColumnGroup> = [];
 
-export function isPblColumnGroup(def: PblColumnGroupDefinition): def is PblColumnGroup {
-  return def instanceof PblColumnGroup || def[PBL_NGRID_COLUMN_GROUP_MARK] === true;
+export function isPblColumnGroup(def: any): def is PblColumnGroup {
+  return def instanceof PblColumnGroup || (def && def[PBL_NGRID_COLUMN_GROUP_MARK] === true);
 }
 
 function getId(value: string | { id: string }): string {

--- a/libs/ngrid/src/lib/table/columns/meta-column.ts
+++ b/libs/ngrid/src/lib/table/columns/meta-column.ts
@@ -8,8 +8,8 @@ import { parseStyleWidth, initDefinitions } from './utils';
 const PBL_NGRID_META_COLUMN_MARK = Symbol('PblMetaColumn');
 const CLONE_PROPERTIES: Array<keyof PblMetaColumn> = ['kind', 'rowIndex'];
 
-export function isPblMetaColumn(def: PblMetaColumnDefinition): def is PblMetaColumn {
-  return def instanceof PblMetaColumn || def[PBL_NGRID_META_COLUMN_MARK] === true;
+export function isPblMetaColumn(def: any): def is PblMetaColumn {
+  return def instanceof PblMetaColumn || (def && def[PBL_NGRID_META_COLUMN_MARK] === true);
 }
 
 export class PblMetaColumn implements PblMetaColumnDefinition {
@@ -132,7 +132,7 @@ export class PblMetaColumn implements PblMetaColumnDefinition {
   attach(columnDef: PblNgridColumnDef<PblMetaColumn>): void {
     this.detach();
     this._columnDef = columnDef;
-    this.columnDef.updateWidth(this.width || this.defaultWidth);
+    this.columnDef.updateWidth(this.width || this.defaultWidth, 'attach');
   }
 
   detach(): void {
@@ -142,7 +142,7 @@ export class PblMetaColumn implements PblMetaColumnDefinition {
   updateWidth(fallbackDefault: string): void {
     this.defaultWidth = fallbackDefault || '';
     if (this.columnDef) {
-      this.columnDef.updateWidth(this.width || fallbackDefault);
+      this.columnDef.updateWidth(this.width || fallbackDefault, 'update');
     }
   }
 }

--- a/libs/ngrid/src/lib/table/directives/cell-def.ts
+++ b/libs/ngrid/src/lib/table/directives/cell-def.ts
@@ -6,7 +6,7 @@ import {
   OnDestroy,
 } from '@angular/core';
 
-import { COLUMN, PblColumnTypeDefinitionDataMap, PblColumn, PblMetaColumn } from '../columns';
+import { COLUMN, PblColumnTypeDefinitionDataMap, PblColumn, PblMetaColumn, isPblColumn } from '../columns';
 import { PblNgridCellContext, PblNgridMetaCellContext } from '../context/index';
 import { PblNgridRegistryService } from '../services/table-registry.service';
 
@@ -146,7 +146,7 @@ export function findCellDef<T = any>(registry: PblNgridRegistryService, colDef: 
 
   if (cellDefs) {
     let type: Pick<PblMetaColumn, 'id' | 'type'>;
-    if (colDef instanceof PblColumn) {
+    if (isPblColumn(colDef)) {
       switch (kind) {
         case 'headerCell':
           if (colDef.headerType) {

--- a/libs/ngrid/src/lib/table/features/virtual-scroll/virtual-scroll-viewport.component.html
+++ b/libs/ngrid/src/lib/table/features/virtual-scroll/virtual-scroll-viewport.component.html
@@ -4,7 +4,7 @@
   Wrap the rendered content in an element that will be used to offset it based on the scroll
   position.
 -->
-<div #contentWrapper [class.cdk-virtual-scroll-content-wrapper]="enabled" style="width: 100%" [style.minWidth.px]="minWidth">
+<div #contentWrapper [class.cdk-virtual-scroll-content-wrapper]="enabled" style="width: 100%" [style.minWidth.px]="_minWidth$ | async">
   <ng-content></ng-content>
 </div>
 
@@ -17,6 +17,6 @@
      [style.transform]="_totalContentSizeTransform"></div>
 <div *ngIf="pblFillerHeight && enabled"
     class="pbl-ngrid-space-fill"
-    [style.minWidth.px]="minWidth"
+    [style.minWidth.px]="_minWidth$ | async"
     [style.top.px]="ngeRenderedContentSize"
     [style.height]="pblFillerHeight"></div>

--- a/libs/ngrid/src/lib/table/features/virtual-scroll/virtual-scroll-viewport.component.ts
+++ b/libs/ngrid/src/lib/table/features/virtual-scroll/virtual-scroll-viewport.component.ts
@@ -1,4 +1,5 @@
 import { Observable, Subject } from 'rxjs';
+import { filter, map } from 'rxjs/operators';
 
 import {
   AfterViewInit,
@@ -82,8 +83,6 @@ export class PblCdkVirtualScrollViewportComponent extends CdkVirtualScrollViewpo
    */
   readonly offsetChange: Observable<number>;
 
-  @Input() minWidth: number;
-
   @Input() stickyRowHeaderContainer: HTMLElement;
   @Input() stickyRowFooterContainer: HTMLElement;
 
@@ -158,6 +157,10 @@ export class PblCdkVirtualScrollViewportComponent extends CdkVirtualScrollViewpo
     return this.elementRef.nativeElement.getBoundingClientRect().height;
   }
 
+  get scrollWidth(): number {
+    return this.elementRef.nativeElement.scrollWidth;
+  }
+
   /// TODO(shlomiassaf): Remove when not supporting 8.1.2 and below
   /// COMPATIBILITY 8.1.2- <-> 8.1.3+
     /** A string representing the `style.width` property value to be used for the spacer element. */
@@ -171,6 +174,8 @@ export class PblCdkVirtualScrollViewportComponent extends CdkVirtualScrollViewpo
    */
   _totalContentSizeTransform = '';
  /// COMPATIBILITY 8.1.2- <-> 8.1.3+
+
+  readonly _minWidth$: Observable<number>;
 
   private offsetChange$ = new Subject<number>();
   private offset: number;
@@ -207,6 +212,13 @@ export class PblCdkVirtualScrollViewportComponent extends CdkVirtualScrollViewpo
     }
     pluginCtrl.extApi.setViewport(this);
     this.offsetChange = this.offsetChange$.asObservable();
+
+    this._minWidth$ = pluginCtrl.events
+      .pipe(
+        filter(event => event.kind === 'onResizeRow'),
+        map( e => this.table.columnApi.visibleColumns.reduce( (p, c) => p + c.sizeInfo.width, 0 ) ),
+        UnRx(this)
+      );
   }
 
   ngOnInit(): void {

--- a/libs/ngrid/src/lib/table/table.component.html
+++ b/libs/ngrid/src/lib/table/table.component.html
@@ -30,7 +30,7 @@
 <div class="pbl-ngrid-container">
   <ng-container #beforeTable></ng-container>
   <div pbl-ngrid-fixed-meta-row-container="header"></div>
-  <pbl-cdk-virtual-scroll-viewport class="pbl-ngrid-scroll-container" [minWidth]="_cdkTable?.minWidth"
+  <pbl-cdk-virtual-scroll-viewport class="pbl-ngrid-scroll-container"
                                    [stickyRowHeaderContainer]="stickyRowHeaderContainer" [stickyRowFooterContainer]="stickyRowFooterContainer">
     <pbl-cdk-table tabindex="-1">
       <!-- Row templates. The columns used are set at the row template level -->
@@ -53,7 +53,7 @@
        <!-- HEADER-RECORD-FOOTER CELL DEF -->
       <ng-container *ngFor="let c of columnApi.visibleColumns;" [pblNgridColumnDef]="c">
         <!-- TABLE HEADER CELL DEF -->
-        <pbl-ngrid-header-cell #hCell="ngridHeaderCell" *cdkHeaderCellDef="let row" [observeSize]="c"></pbl-ngrid-header-cell>
+        <pbl-ngrid-header-cell *cdkHeaderCellDef="let row" [observeSize]="c"></pbl-ngrid-header-cell>
         <!-- RECORD CELL DEF -->
         <pbl-ngrid-cell #cell="pblNgridCell" *cdkCellDef="let row; pblRowContext as pblRowContext"
                         [rowCtx]="pblRowContext" [attr.tabindex]="cellFocus" [attr.id]="c.id">

--- a/libs/ngrid/src/lib/table/table.component.ts
+++ b/libs/ngrid/src/lib/table/table.component.ts
@@ -36,7 +36,7 @@ import { DataSourcePredicate, DataSourceFilterToken, PblNgridSortDefinition, Pbl
 import { PblCdkTableComponent } from './pbl-cdk-table/pbl-cdk-table.component';
 import { resetColumnWidths } from './utils';
 import { findCellDef } from './directives/cell-def';
-import { PblColumn, PblColumnStore, PblMetaColumnStore, PblNgridColumnSet, PblNgridColumnDefinitionSet } from './columns';
+import { PblColumn, PblColumnStore, PblMetaColumnStore, PblNgridColumnSet, PblNgridColumnDefinitionSet, isPblColumn } from './columns';
 import { PblNgridCellContext, PblNgridMetaCellContext, ContextApi, PblNgridContextApi, PblNgridRowContext } from './context/index';
 import { PblNgridRegistryService } from './services/table-registry.service';
 import { PblNgridConfigService } from './services/config';
@@ -672,8 +672,8 @@ export class PblNgridComponent<T = any> implements AfterContentInit, AfterViewIn
    * Updates the column sizes for all columns in the table based on the column definition metadata for each column.
    * The final width represent a static width, it is the value as set in the definition (except column without width, where the calculated global width is set).
    */
-  resetColumnsWidth(options?: { tableMarkForCheck?: boolean; metaMarkForCheck?: boolean; }): void {
-    resetColumnWidths(this._store.getStaticWidth(), this._store.columns, this._store.metaColumns, options);
+  resetColumnsWidth(): void {
+    resetColumnWidths(this._store.getStaticWidth(), this._store.columns, this._store.metaColumns);
   }
 
   /**
@@ -703,9 +703,6 @@ export class PblNgridComponent<T = any> implements AfterContentInit, AfterViewIn
         g.minWidth = undefined;
         g.updateWidth(`0px`);
       }
-      if (g.columnDef) {
-        g.columnDef.markForCheck();
-      }
     }
   }
 
@@ -733,7 +730,7 @@ export class PblNgridComponent<T = any> implements AfterContentInit, AfterViewIn
 
     // if the max lock state has changed we need to update re-calculate the static width's again.
     if (rowWidth.maxWidthLockChanged) {
-      resetColumnWidths(this._store.getStaticWidth(), this._store.columns, this._store.metaColumns, { tableMarkForCheck: true });
+      resetColumnWidths(this._store.getStaticWidth(), this._store.columns, this._store.metaColumns);
       this.resizeColumns(columns);
       return;
     }
@@ -888,7 +885,7 @@ export class PblNgridComponent<T = any> implements AfterContentInit, AfterViewIn
     if (this._viewport) {
       this._viewport.checkViewportSize();
     }
-    this.resetColumnsWidth();
+    // this.resetColumnsWidth();
     this.resizeColumns();
   }
 
@@ -1016,7 +1013,7 @@ export class PblNgridComponent<T = any> implements AfterContentInit, AfterViewIn
     const defaultHeaderCellTemplate = this.registry.getMultiDefault('headerCell') || { tRef: this._fbHeaderCell };
     const defaultFooterCellTemplate = this.registry.getMultiDefault('footerCell') || { tRef: this._fbFooterCell };
     for (const col of columns) {
-      if (col instanceof PblColumn) {
+      if (isPblColumn(col)) {
         const headerCellDef = findCellDef<T>(this.registry, col, 'headerCell', true) || defaultHeaderCellTemplate;
         const footerCellDef = findCellDef<T>(this.registry, col, 'footerCell', true) || defaultFooterCellTemplate;
         col.headerCellTpl = headerCellDef.tRef;

--- a/libs/ngrid/src/lib/table/utils/helpers.ts
+++ b/libs/ngrid/src/lib/table/utils/helpers.ts
@@ -35,28 +35,21 @@ export function deepPathSet(item: any, col: PblColumnDefinition, value: any): vo
  */
 export function resetColumnWidths(rowWidth: StaticColumnWidthLogic,
                                   tableColumns: PblColumn[],
-                                  metaColumns: PblMetaColumnStore[],
-                                  options: { tableMarkForCheck?: boolean; metaMarkForCheck?: boolean; } = {}): void {
+                                  metaColumns: PblMetaColumnStore[]): void {
   const { pct, px } = rowWidth.defaultColumnWidth;
   const defaultWidth = `calc(${pct}% - ${px}px)`;
 
-  let mark = !!options.tableMarkForCheck;
   for (const c of tableColumns) {
     c.setDefaultWidth(defaultWidth);
-    c.updateWidth(mark);
+    c.updateWidth();
   }
 
-  mark = !!options.metaMarkForCheck;
   for (const m of metaColumns) {
     for (const c of [m.header, m.footer]) {
       if (c) {
         c.updateWidth('');
-        if (mark) {
-          c.columnDef.markForCheck();
-        }
       }
     }
-
     // We don't handle groups because they are handled by `PblNgridComponent.resizeRows()`
     // which set the width for each.
   }

--- a/libs/ngrid/state/src/lib/core/built-in-handlers/column-def/children.ts
+++ b/libs/ngrid/state/src/lib/core/built-in-handlers/column-def/children.ts
@@ -41,7 +41,7 @@ export function registerColumnDefChildHandlers() {
       if (activeColumn) {
         switch (key) {
           case 'width':
-            activeColumn.updateWidth(true, stateValue as any);
+            activeColumn.updateWidth(stateValue as any);
             break;
         }
       }


### PR DESCRIPTION
This commit changes how each column detects width changes, how it emits them and how each cell propagte the changes.

The old way was to have a differ that checked the entire column for changes, which missed changes on the column-def instance, so now these are all removed and each change to the width fires an event with the reason for the change so each cell directive can choose if to pass it to the element or not

fixes #57