### PR TITLE
Added the option to select the icon for the matHeaderContextMenuTrigger

### DIFF
--- a/libs/ngrid-material/context-menu/src/lib/header-context/header-context-menu-trigger.html
+++ b/libs/ngrid-material/context-menu/src/lib/header-context/header-context-menu-trigger.html
@@ -1,1 +1,1 @@
-<mat-icon style="height: 16px; width: 16px; font-size: 16px; line-height: 16px;">more_vert</mat-icon>
+<mat-icon style="height: 16px; width: 16px; font-size: 16px; line-height: 16px;" >{{ matHeaderTriggerIcon }}</mat-icon>

--- a/libs/ngrid-material/context-menu/src/lib/header-context/header-context-menu-trigger.ts
+++ b/libs/ngrid-material/context-menu/src/lib/header-context/header-context-menu-trigger.ts
@@ -18,6 +18,8 @@ const DEFAULT_CONFIG: PblNgridOverlayPanelConfig = { hasBackdrop: true, xPos: 'a
 })
 export class MatHeaderContextMenuTrigger {
 
+  @Input('matHeaderTriggerIcon') icon: string = 'more_vert'
+
   context: PblNgridDataHeaderExtensionContext;
 
   constructor(private plugin: PblNgridMatHeaderContextMenuPlugin, private elRef: ElementRef<HTMLElement>) { }


### PR DESCRIPTION
There are situations in which we need to change the context menu icon to fit the design choice.
For example. using horizontal dots instead of vertical.

Unless I'm unaware of a way that already exists to do that.