### PR TITLE
fix(ngrid/target-events): underfined rowContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 3.1.4 (2021-04-08)
+
+
+### Bug Fixes
+
+* **ngrid/target-events:** underfined rowContext ([80d0e9d](https://github.com/shlomiassaf/ngrid/commit/80d0e9dd796f96c46262abf61174d528ec6f2fd2)), closes [#181](https://github.com/shlomiassaf/ngrid/issues/181)
+
+
+
 ## 3.1.3 (2021-03-31)
 
 

--- a/libs/ngrid-bootstrap/package.json
+++ b/libs/ngrid-bootstrap/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@pebula/ngrid-bootstrap",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "peerDependencies": {
     "@ng-bootstrap/ng-bootstrap": "^8.0.0",
-    "@pebula/ngrid": "3.1.3"
+    "@pebula/ngrid": "3.1.4"
   },
   "dependencies": {
     "tslib": "^2.0.0"

--- a/libs/ngrid-material/package.json
+++ b/libs/ngrid-material/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pebula/ngrid-material",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "peerDependencies": {
     "@angular/material": "^11.0.0",
-    "@pebula/ngrid": "3.1.3"
+    "@pebula/ngrid": "3.1.4"
   }
 }

--- a/libs/ngrid/package.json
+++ b/libs/ngrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pebula/ngrid",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "license": "MIT",
   "peerDependencies": {
     "@angular/core": "^11.0.0",

--- a/libs/ngrid/target-events/src/lib/target-events/target-events-plugin.ts
+++ b/libs/ngrid/target-events/src/lib/target-events/target-events-plugin.ts
@@ -121,6 +121,10 @@ export class PblNgridTargetEventsPlugin<T = any> {
           const columnIndex = this.grid.columnApi.indexOf(column);
           event.column = column;
           (event as Events.PblNgridDataMatrixPoint<T>).context = this.pluginCtrl.extApi.contextApi.getCell(event.rowIndex, columnIndex);
+          if (!(event as Events.PblNgridDataMatrixPoint<T>).context) {
+            this.pluginCtrl.extApi.contextApi.clear(true);
+            (event as Events.PblNgridDataMatrixPoint<T>).context = this.pluginCtrl.extApi.contextApi.getCell(event.rowIndex, columnIndex);
+          }
         } else {
           const store = this.pluginCtrl.extApi.columnStore;
           const rowInfo = (matrixPoint.type === 'header' ? store.metaHeaderRows : store.metaFooterRows)[event.rowIndex];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pebula",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Angular Grid",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
When using keepAlive with target Events and rendering on/off the grid, the datasource is rendered before other things which causes this issue.

Fixes #181