### PR TITLE
fix: remove tilde from use rule

### DIFF
--- a/apps/ngrid-dev-app/src/theme.scss
+++ b/apps/ngrid-dev-app/src/theme.scss
@@ -1,4 +1,4 @@
-@use '~@angular/material' as mat;
+@use '@angular/material' as mat;
 @use '../../../libs/ngrid' as ngrid;
 @use '../../../libs/ngrid-material' as ngrid-material;
 

--- a/apps/ngrid-docs-app/content/concepts/theming/theming-structure.md
+++ b/apps/ngrid-docs-app/content/concepts/theming/theming-structure.md
@@ -50,7 +50,7 @@ To create a custom theme:
 A typical theme file will look something like this:
 
 ```scss
-@use '~@pebula/ngrid' as ngrid;
+@use '@pebula/ngrid' as ngrid;
 
 // 1. Create a palette from a color schema
 // `ngrid.$blue-palett` is a predefined color palette provided by `@pebula/ngrid/theming`

--- a/apps/ngrid-docs-app/content/concepts/theming/theming.md
+++ b/apps/ngrid-docs-app/content/concepts/theming/theming.md
@@ -38,12 +38,12 @@ To create a custom theme:
 2. Create a theme from your palette using `ngrid.define-light-theme` or `ngrid.define-dark-theme`
 3. Render the theme by including the mixin `ngrid.ngrid-theme`
 
-> We assume the **ngrid** namespace defined (`@use '~@pebula/ngrid' as ngrid`)
+> We assume the **ngrid** namespace defined (`@use '@pebula/ngrid' as ngrid`)
 
 A typical theme file will look something like this:
 
 ```scss
-@use '~@pebula/ngrid' as ngrid;
+@use '@pebula/ngrid' as ngrid;
 
 // 1. Create a palette from a color schema
 // `ngrid.$blue-palett` is a predefined color palette provided by `@pebula/ngrid/theming`

--- a/apps/ngrid-docs-app/content/plugins/ngrid-bootstrap/theming.md
+++ b/apps/ngrid-docs-app/content/plugins/ngrid-bootstrap/theming.md
@@ -15,7 +15,7 @@ There are 2 pre-built CSS themes provided in `@pebula/ngrid-bootstrap/themes`:
 If you're using Angular CLI & SCSS, this is as simple as including one line in your `styles.scss` file:
 
 ```scss
-@use '~bootstrap/dist/css/bootstrap';
+@use 'bootstrap/dist/css/bootstrap';
 @use '@pebula/ngrid-bootstrap/themes/default-light.css';
 ```
 

--- a/apps/ngrid-docs-app/content/plugins/ngrid-material/theming.md
+++ b/apps/ngrid-docs-app/content/plugins/ngrid-material/theming.md
@@ -44,7 +44,7 @@ we create a custom **nGrid** theme (which is no surprise):
 2. Create a theme from the palettes using `mat.define-light-theme` or `mat.define-dark-theme`
 3. Render the theme by including the mixin `mat.all-component-themes(`
 
-> We assume the **mat** namespace defined (`@use '~@angular/material' as mat`)
+> We assume the **mat** namespace defined (`@use '@angular/material' as mat`)
 
 Let's [recall](../../../concepts/theming/introduction#customized-themes-scss) the steps required for creating an **nGrid** theme:
 
@@ -52,7 +52,7 @@ Let's [recall](../../../concepts/theming/introduction#customized-themes-scss) th
 2. Create a theme from your palette using `ngrid.define-light-theme` or `ngrid.define-dark-theme`
 3. Render the theme by including the mixin `ngrid.ngrid-theme`
 
-> We assume the **ngrid** namespace defined (`@use '~@pebula/ngrid' as ngrid`)
+> We assume the **ngrid** namespace defined (`@use '@pebula/ngrid' as ngrid`)
 
 When working with material we use the material tools to create a theme object and render the styles. (Step 3)  
 We can use the same theme to render the **nGrid** theme!
@@ -64,9 +64,9 @@ missing definitions and create a new theme that you can send to `ngrid.ngrid-the
 `ngrid.define-light-theme` and `ngrid.define-dark-theme` accept a palette **or a theme**!!
 
 ```scss
-@use '~@angular/material' as mat;
-@use '~@pebula/ngrid' as ngrid;
-@use '~@pebula/ngrid-material' as ngrid-material;
+@use '@angular/material' as mat;
+@use '@pebula/ngrid' as ngrid;
+@use '@pebula/ngrid-material' as ngrid-material;
 
 $typography-config: mat.define-typography-config();
 @include mat.core($typography-config);

--- a/apps/ngrid-docs-app/src/styles/_default-theme.scss
+++ b/apps/ngrid-docs-app/src/styles/_default-theme.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use '~@angular/material' as mat;
+@use '@angular/material' as mat;
 @use '../../../../libs/ngrid' as ngrid;
 
 @function shell-light-theme($primary-palette, $accent-palette) {

--- a/apps/ngrid-docs-app/src/styles/_markdown.scss
+++ b/apps/ngrid-docs-app/src/styles/_markdown.scss
@@ -1,6 +1,6 @@
 @use 'sass:map';
 @use 'sass:color';
-@use '~@angular/material' as mat;
+@use '@angular/material' as mat;
 
 @import "~primer-support/index.scss";
 @import "~primer-markdown/lib/markdown-body.scss";

--- a/apps/ngrid-docs-app/src/styles/_shell-app.theme.scss
+++ b/apps/ngrid-docs-app/src/styles/_shell-app.theme.scss
@@ -1,6 +1,6 @@
 @use 'sass:map';
 @use 'sass:color';
-@use '~@angular/material' as mat;
+@use '@angular/material' as mat;
 
 @mixin render-shell-app-theme($theme, $typography-config, $typography-selector: '.mat-typography') {
   $primary: map.get($theme, primary);

--- a/apps/ngrid-docs-app/src/styles/_toc.scss
+++ b/apps/ngrid-docs-app/src/styles/_toc.scss
@@ -1,6 +1,6 @@
 @use 'sass:map';
 @use 'sass:color';
-@use '~@angular/material' as mat;
+@use '@angular/material' as mat;
 
 @mixin render($theme) {
   $primary: map.get($theme, primary);

--- a/apps/ngrid-docs-app/src/styles/main.scss
+++ b/apps/ngrid-docs-app/src/styles/main.scss
@@ -1,4 +1,4 @@
-@use '~@angular/material' as mat;
+@use '@angular/material' as mat;
 @use 'default-theme';
 @use 'shell-app.theme' as shell;
 @use 'markdown' as md;

--- a/libs/ngrid-material/context-menu/theming/_index.scss
+++ b/libs/ngrid-material/context-menu/theming/_index.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use '~@angular/material' as mat;
+@use '@angular/material' as mat;
 
 @mixin ngrid-material-context-menu-theme($theme) {
   $primary: map.get($theme, primary);

--- a/libs/ngrid-material/theming/prebuilt/deeppurple-amber.scss
+++ b/libs/ngrid-material/theming/prebuilt/deeppurple-amber.scss
@@ -1,4 +1,4 @@
-@use '~@angular/material' as mat;
+@use '@angular/material' as mat;
 @use '../../../ngrid' as ngrid;
 @use '../../index' as ngrid-material;
 

--- a/libs/ngrid-material/theming/prebuilt/indigo-pink.scss
+++ b/libs/ngrid-material/theming/prebuilt/indigo-pink.scss
@@ -1,4 +1,4 @@
-@use '~@angular/material' as mat;
+@use '@angular/material' as mat;
 @use '../../../ngrid' as ngrid;
 @use '../../index' as ngrid-material;
 

--- a/libs/ngrid-material/theming/prebuilt/pink-bluegrey.scss
+++ b/libs/ngrid-material/theming/prebuilt/pink-bluegrey.scss
@@ -1,4 +1,4 @@
-@use '~@angular/material' as mat;
+@use '@angular/material' as mat;
 @use '../../../ngrid' as ngrid;
 @use '../../index' as ngrid-material;
 

--- a/libs/ngrid-material/theming/prebuilt/purple-green.scss
+++ b/libs/ngrid-material/theming/prebuilt/purple-green.scss
@@ -1,4 +1,4 @@
-@use '~@angular/material' as mat;
+@use '@angular/material' as mat;
 @use '../../../ngrid' as ngrid;
 @use '../../index' as ngrid-material;
 

--- a/libs/ngrid/schematics/ng-add/theming/create-custom-theme.ts
+++ b/libs/ngrid/schematics/ng-add/theming/create-custom-theme.ts
@@ -9,7 +9,7 @@
 /** Create custom theme for the given application configuration. */
 export function createCustomTheme(name: string = 'app') {
 return `
-@use '~@pebula/ngrid' as ngrid;
+@use '@pebula/ngrid' as ngrid;
 
 $${name}-palette: ngrid.define-palette(ngrid.$blue-palette);
 


### PR DESCRIPTION
In order to use ngrid with angular 13 apps the tilde symbol should be removed from the use rule since it's isn't supported in webpack 5.