### PR TITLE
Attempted fix for ERROR TypeError: Cannot read properties of undefined (reading '$implicit')

### DIFF
--- a/libs/ngrid/target-events/src/lib/target-events/target-events-plugin.ts
+++ b/libs/ngrid/target-events/src/lib/target-events/target-events-plugin.ts
@@ -160,8 +160,12 @@ export class PblNgridTargetEventsPlugin<T = any> {
         if (matrixPoint) {
           const event: Events.PblNgridRowEvent<T> = { ...matrixPoint, source, rowTarget } as any;
           if (matrixPoint.type === 'data') {
-            (event as Events.PblNgridDataMatrixRow<T>).context = this.pluginCtrl.extApi.contextApi.getRow(matrixPoint.rowIndex);
-            (event as Events.PblNgridDataMatrixRow<T>).row = (event as Events.PblNgridDataMatrixRow<T>).context.$implicit;
+            const row = this.pluginCtrl.extApi.contextApi.getRow(matrixPoint.rowIndex);
+            if (!row) {
+              return undefined;
+            }
+            (event as Events.PblNgridDataMatrixRow<T>).context = row;
+            (event as Events.PblNgridDataMatrixRow<T>).row = row.$implicit;
           }
 
           /*  If `subType !== 'data'` it can only be `meta` because `metadataFromElement()` does not handle `meta-group` subType.


### PR DESCRIPTION
Please consider and verify this fix for v4.0 - with row selection it fixes the crash issue when accessing context.$implicit when mouse movements are are not picking up grid row.

It might be a temporary fix (row should be found when mouse is over grid) but clears the only reproducible issue with v4.0 I could find in our tests.