### PR TITLE
Fixed a bug in ContextApi.focusChanged

### DIFF
--- a/libs/ngrid/src/lib/grid/context/api.ts
+++ b/libs/ngrid/src/lib/grid/context/api.ts
@@ -40,6 +40,7 @@ export class ContextApi<T = any> {
   readonly focusChanged: Observable<PblNgridFocusChangedEvent> = this.focusChanged$
     .pipe(
       buffer<PblNgridFocusChangedEvent>(this.focusChanged$.pipe(debounceTime(0, asapScheduler))),
+      filter(events => events.length > 0),
       map( events => ({ prev: events[0].prev, curr: events[events.length - 1].curr }) )
     );
 


### PR DESCRIPTION
When focusChanged$ completes on destroy method, it causes the buffer to emit an empty array of events if it has no items in the buffer

Fixes #215