### PR TITLE
fix undefined exception

### DIFF
--- a/libs/ngrid/src/lib/grid/context/api.ts
+++ b/libs/ngrid/src/lib/grid/context/api.ts
@@ -40,7 +40,7 @@ export class ContextApi<T = any> {
   readonly focusChanged: Observable<PblNgridFocusChangedEvent> = this.focusChanged$
     .pipe(
       buffer<PblNgridFocusChangedEvent>(this.focusChanged$.pipe(debounceTime(0, asapScheduler))),
-      map( events => ({ prev: events[0].prev, curr: events[events.length - 1].curr }) )
+      map( events => ({ prev: events[0]?.prev, curr: events[events.length - 1]?.curr }) )
     );
 
   /**


### PR DESCRIPTION
bug description:
when there is a ngrid table on the screen and clicking the browser previous button, it throws an exception of `Cannot read properties of undefined (reading 'prev')` because the events array is empty