### PR TITLE
fix(ngrid/detail-row): elementRef for row out of view doesn't have parentElement

### DIFF
--- a/libs/ngrid/detail-row/src/lib/detail-row/row.ts
+++ b/libs/ngrid/detail-row/src/lib/detail-row/row.ts
@@ -69,7 +69,9 @@ export class PblNgridDetailRowComponent extends PblNgridRowComponent implements 
     tradeEvents.cellClick
       .pipe(unrx(this))
       .subscribe( event => {
-        if (event.type === 'data' && event.row === this.context.$implicit) {
+        if (event.type === 'data' && 
+            !this.context.outOfView && 
+            event.row === this.context.$implicit) {
           const { excludeToggleFrom } = this.plugin;
           if (!excludeToggleFrom || !excludeToggleFrom.some( c => event.column.id === c )) {
             this.toggle();
@@ -80,7 +82,9 @@ export class PblNgridDetailRowComponent extends PblNgridRowComponent implements 
     tradeEvents.rowClick
       .pipe(unrx(this))
       .subscribe( event => {
-        if (!event.root && event.type === 'data' && event.row === this.context.$implicit) {
+        if (!event.root && 
+            !this.context.outOfView && 
+            event.type === 'data' && event.row === this.context.$implicit) {
           this.toggle();
         }
       });


### PR DESCRIPTION
When working with virtual scrolling there are some situations where multiple rows have the same data in their context. Only one is in the view and the other is out of view. In that case, opening a detail row should apply only to rows that are in view.